### PR TITLE
Modify enqueue_block_assets to init because it doesn't show in admin …

### DIFF
--- a/inc/classes/class-assets.php
+++ b/inc/classes/class-assets.php
@@ -29,7 +29,7 @@ class Assets {
 		 * The 'enqueue_block_assets' hook includes styles and scripts both in editor and frontend,
 		 * except when is_admin() is used to include them conditionally
 		 */
-		add_action( 'enqueue_block_assets', [ $this, 'enqueue_editor_assets' ] );
+		add_action( 'init', [ $this, 'enqueue_editor_assets' ] );
 	}
 
 	public function register_styles() {


### PR DESCRIPTION
According to below descriptions from wordpress site, by using "enqueue_block_assets" nothing show in toggle block inserter. 

https://wordpress.org/support/topic/custom-block-not-showing-in-insert-block-list/